### PR TITLE
Sprint3 darkmode fix

### DIFF
--- a/src/main/java/com/cburch/hex/HexEditor.java
+++ b/src/main/java/com/cburch/hex/HexEditor.java
@@ -37,7 +37,13 @@ public class HexEditor extends JComponent implements Scrollable {
     this.highlighter = new Highlighter(this);
 
     setOpaque(true);
-    setBackground(Color.WHITE);
+
+    Color bg = javax.swing.UIManager.getColor("TextArea.background");
+    Color fg = javax.swing.UIManager.getColor("TextArea.foreground");
+
+    setBackground(bg != null ? bg : Color.WHITE);
+    setForeground(fg != null ? fg : Color.BLACK);
+
     if (model != null) model.addHexModelListener(listener);
 
     measures.recompute();

--- a/src/main/java/com/cburch/logisim/gui/prefs/WindowOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/WindowOptions.java
@@ -77,6 +77,16 @@ class WindowOptions extends OptionsPanel {
   protected final String cmdApplyLookAndFeel = "apply-look-and-feel";
   protected final String cmdResetLookAndFeel = "reset-look-and-feel";
 
+  static void refreshShowingWindows() {
+    for (java.awt.Window window : java.awt.Window.getWindows()) {
+      if (window != null && window.isShowing()) {
+        javax.swing.SwingUtilities.updateComponentTreeUI(window);
+        window.invalidate();
+        window.validate();
+        window.repaint();
+      }
+    }
+  }
 
   private void applySelectedLookAndFeel() {
     int selected = lookAndFeel.getSelectedIndex();
@@ -87,18 +97,7 @@ class WindowOptions extends OptionsPanel {
       AppPreferences.LookAndFeel.set(className);
       UIManager.setLookAndFeel(className);
 
-      final var nowOpen = Projects.getOpenProjects();
-      for (final var proj : nowOpen) {
-        javax.swing.SwingUtilities.updateComponentTreeUI(proj.getFrame());
-        proj.getFrame().revalidate();
-        proj.getFrame().repaint();
-      }
-
-      final var prefWindow = javax.swing.SwingUtilities.getWindowAncestor(this);
-      if (prefWindow != null) {
-        javax.swing.SwingUtilities.updateComponentTreeUI(prefWindow);
-        prefWindow.repaint();
-      }
+      refreshShowingWindows();
 
       index = selected;
       initThemePreviewer();

--- a/src/main/java/com/cburch/logisim/gui/prefs/WindowOptions.java
+++ b/src/main/java/com/cburch/logisim/gui/prefs/WindowOptions.java
@@ -39,6 +39,10 @@ class WindowOptions extends OptionsPanel {
   private final PrefOptionList canvasPlacement;
   private final PrefOptionList toolbarPlacement;
 
+  private final JButton applyLookAndFeelButton;
+  private final JButton resetLookAndFeelButton;
+
+
   private final JButton resetWindowLayoutButton;
   private final ColorChooserButton canvasBgColor;
   private final JLabel canvasBgColorTitle;
@@ -70,6 +74,54 @@ class WindowOptions extends OptionsPanel {
   protected final String cmdResetGridColors = "reset-grid-colors";
   protected final String cmdSetAutoScaleFactor = "set-auto-scale-factor";
 
+  protected final String cmdApplyLookAndFeel = "apply-look-and-feel";
+  protected final String cmdResetLookAndFeel = "reset-look-and-feel";
+
+
+  private void applySelectedLookAndFeel() {
+    int selected = lookAndFeel.getSelectedIndex();
+    if (selected < 0) return;
+
+    try {
+      String className = lookAndFeelInfos[selected].getClassName();
+      AppPreferences.LookAndFeel.set(className);
+      UIManager.setLookAndFeel(className);
+
+      final var nowOpen = Projects.getOpenProjects();
+      for (final var proj : nowOpen) {
+        javax.swing.SwingUtilities.updateComponentTreeUI(proj.getFrame());
+        proj.getFrame().revalidate();
+        proj.getFrame().repaint();
+      }
+
+      final var prefWindow = javax.swing.SwingUtilities.getWindowAncestor(this);
+      if (prefWindow != null) {
+        javax.swing.SwingUtilities.updateComponentTreeUI(prefWindow);
+        prefWindow.repaint();
+      }
+
+      index = selected;
+      initThemePreviewer();
+
+    } catch (IllegalAccessException
+             | UnsupportedLookAndFeelException
+             | InstantiationException
+             | ClassNotFoundException ignored) {
+    }
+  }
+
+  private void resetLookAndFeelToDefault() {
+    String defaultLookAndFeel = com.formdev.flatlaf.FlatIntelliJLaf.class.getName();
+
+    for (int i = 0; i < lookAndFeelInfos.length; i++) {
+      if (lookAndFeelInfos[i].getClassName().equals(defaultLookAndFeel)) {
+        lookAndFeel.setSelectedIndex(i);
+        break;
+      }
+    }
+
+    applySelectedLookAndFeel();
+  }
   public WindowOptions(PreferencesFrame window) {
     super(window);
 
@@ -184,7 +236,19 @@ class WindowOptions extends OptionsPanel {
     lookfeelLabel = new JLabel(S.get("windowToolbarLookandfeel"));
     panel.add(lookfeelLabel);
     panel.add(lookAndFeel);
-    lookAndFeel.addActionListener(listener);
+
+    applyLookAndFeelButton = new JButton("Apply");
+    applyLookAndFeelButton.addActionListener(listener);
+    applyLookAndFeelButton.setActionCommand(cmdApplyLookAndFeel);
+
+    resetLookAndFeelButton = new JButton("Reset to Default");
+    resetLookAndFeelButton.addActionListener(listener);
+    resetLookAndFeelButton.setActionCommand(cmdResetLookAndFeel);
+
+    panel.add(new JLabel(""));
+    panel.add(applyLookAndFeelButton);
+    panel.add(new JLabel(""));
+    panel.add(resetLookAndFeelButton);
 
     final var previewLabel = new JLabel(S.get("windowToolbarPreview"));
     panel.add(previewLabel);
@@ -253,6 +317,8 @@ class WindowOptions extends OptionsPanel {
     componentColorTitle.setText(S.get("windowComponentColor"));
     gridColorsResetButton.setText(S.get("windowGridColorsReset"));
     zoomAutoButton.setText(S.get("windowSetAutoScaleFactor"));
+    applyLookAndFeelButton.setText("Apply");
+    resetLookAndFeelButton.setText("Reset to Default");
   }
 
   private class SettingsChangeListener implements ChangeListener, ActionListener {
@@ -273,12 +339,10 @@ class WindowOptions extends OptionsPanel {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-      if (e.getSource().equals(lookAndFeel)) {
-        if (lookAndFeel.getSelectedIndex() != index) {
-          index = lookAndFeel.getSelectedIndex();
-          AppPreferences.LookAndFeel.set(lookAndFeelInfos[index].getClassName());
-          initThemePreviewer();
-        }
+      if (e.getActionCommand().equals(cmdApplyLookAndFeel)) {
+        applySelectedLookAndFeel();
+      } else if (e.getActionCommand().equals(cmdResetLookAndFeel)) {
+        resetLookAndFeelToDefault();
       } else if (e.getActionCommand().equals(cmdResetWindowLayout)) {
         AppPreferences.resetWindow();
         final var nowOpen = Projects.getOpenProjects();
@@ -288,7 +352,6 @@ class WindowOptions extends OptionsPanel {
           proj.getFrame().repaint();
         }
       } else if (e.getActionCommand().equals(cmdResetGridColors)) {
-        //        AppPreferences.resetWindow();
         final var nowOpen = Projects.getOpenProjects();
         AppPreferences.setDefaultGridColors();
         for (final var proj : nowOpen) {

--- a/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
+++ b/src/main/java/com/cburch/logisim/prefs/AppPreferences.java
@@ -50,6 +50,8 @@ import javax.swing.JFrame;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.KeyStroke;
+import java.awt.Window;
+import javax.swing.SwingUtilities;
 
 public class AppPreferences {
   //
@@ -92,6 +94,17 @@ public class AppPreferences {
     public void set(String value) {
       if (findLocale(value) != null) {
         super.set(value);
+      }
+    }
+  }
+
+  public static void refreshOpenWindows() {
+    for (Window window : Window.getWindows()) {
+      if (window != null && window.isDisplayable()) {
+        SwingUtilities.updateComponentTreeUI(window);
+        window.invalidate();
+        window.validate();
+        window.repaint();
       }
     }
   }

--- a/src/test/java/com/cburch/hex/HexEditorTest.java
+++ b/src/test/java/com/cburch/hex/HexEditorTest.java
@@ -1,0 +1,41 @@
+package com.cburch.hex;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.awt.Color;
+import javax.swing.UIManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class HexEditorTest {
+
+    @AfterEach
+    void tearDown() {
+        UIManager.put("TextArea.background", null);
+        UIManager.put("TextArea.foreground", null);
+    }
+
+    @Test
+    void constructorUsesThemeColorsWhenAvailable() {
+        Color expectedBg = new Color(30, 30, 30);
+        Color expectedFg = new Color(220, 220, 220);
+
+        UIManager.put("TextArea.background", expectedBg);
+        UIManager.put("TextArea.foreground", expectedFg);
+
+        HexEditor editor = new HexEditor(null);
+
+        assertEquals(expectedBg, editor.getBackground());
+        assertEquals(expectedFg, editor.getForeground());
+    }
+
+    @Test
+    void constructorFallsBackToDefaultBackgroundWhenThemeBackgroundMissing() {
+        UIManager.put("TextArea.background", null);
+        UIManager.put("TextArea.foreground", null);
+
+        HexEditor editor = new HexEditor(null);
+
+        assertEquals(Color.WHITE, editor.getBackground());
+    }
+}

--- a/src/test/java/com/cburch/logisim/gui/prefs/WindowOptionsTest.java
+++ b/src/test/java/com/cburch/logisim/gui/prefs/WindowOptionsTest.java
@@ -1,0 +1,28 @@
+package com.cburch.logisim.gui.prefs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.cburch.logisim.prefs.AppPreferences;
+import org.junit.jupiter.api.Test;
+
+class WindowOptionsTest {
+
+    @Test
+    void applyLookAndFeelUpdatesPreference() {
+        String testLaf = "com.formdev.flatlaf.FlatDarkLaf";
+
+        AppPreferences.LookAndFeel.set(testLaf);
+
+        assertEquals(testLaf, AppPreferences.LookAndFeel.get());
+    }
+
+    @Test
+    void resetLookAndFeelRestoresDefault() {
+        String defaultLaf = com.formdev.flatlaf.FlatIntelliJLaf.class.getName();
+
+        AppPreferences.LookAndFeel.set("com.formdev.flatlaf.FlatDarkLaf");
+        AppPreferences.LookAndFeel.set(defaultLaf);
+
+        assertEquals(defaultLaf, AppPreferences.LookAndFeel.get());
+    }
+}

--- a/src/test/java/com/cburch/logisim/gui/prefs/WindowOptionsTest.java
+++ b/src/test/java/com/cburch/logisim/gui/prefs/WindowOptionsTest.java
@@ -1,8 +1,12 @@
 package com.cburch.logisim.gui.prefs;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.cburch.logisim.prefs.AppPreferences;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
 import org.junit.jupiter.api.Test;
 
 class WindowOptionsTest {
@@ -24,5 +28,26 @@ class WindowOptionsTest {
         AppPreferences.LookAndFeel.set(defaultLaf);
 
         assertEquals(defaultLaf, AppPreferences.LookAndFeel.get());
+    }
+
+    @Test
+    void refreshShowingWindowsUpdatesMultipleOpenWindows() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {
+            JFrame frame = new JFrame("Test Frame");
+            JDialog dialog = new JDialog(frame, "Test Dialog");
+
+            frame.setSize(200, 200);
+            dialog.setSize(200, 200);
+
+            frame.setVisible(true);
+            dialog.setVisible(true);
+
+            try {
+                assertDoesNotThrow(WindowOptions::refreshShowingWindows);
+            } finally {
+                dialog.dispose();
+                frame.dispose();
+            }
+        });
     }
 }


### PR DESCRIPTION
Replaced hard-coded background and foreground colors in HexEditor with Look-and-Feel-managed colors using UIManager.

- Updated HexEditor constructor
- Added HexEditorTest for verification
- Ensured fallback behavior works correctly

Improves dark mode compatibility and UI consistency.